### PR TITLE
Adds interpolate and reproject input data step for USFS climate run inputs

### DIFF
--- a/input-data/tensor/USFS_fire_risk/RDS-2025-0006/03_reproject_and_interpolate.py
+++ b/input-data/tensor/USFS_fire_risk/RDS-2025-0006/03_reproject_and_interpolate.py
@@ -1,0 +1,70 @@
+# Script to modify the 2011 and 2014 USFS climate run datasets:
+# - Reproject from EPSG:5070 to EPSG:4326 (X/Y -> lat/lon)
+# - Interpolate from 270m to 30m
+# - Note: This uses the USFS Community Risk 30m dataset as an input for interpolation
+
+
+import coiled
+import icechunk
+import xarray as xr
+from icechunk.xarray import to_icechunk
+from odc.geo.xr import assign_crs, xr_reproject
+
+from ocr import catalog
+from ocr.utils import interpolate_to_30
+
+
+def load_climate_run_ds(climate_run_year: str):
+    climate_run_ds = catalog.get_dataset(f'{climate_run_year}-climate-run').to_xarray()
+    # downcast to float32
+    for var in list(climate_run_ds):
+        climate_run_ds[var] = climate_run_ds[var].astype('float32')
+    return climate_run_ds
+
+
+def write_to_icechunk(ds: xr.Dataset, climate_run_year: str):
+    storage = icechunk.s3_storage(
+        bucket='carbonplan-ocr',
+        prefix=f'input/fire-risk/tensor/USFS/{climate_run_year}_climate_run_30m_4326_chunked_icechunk',
+        region='us-west-2',
+    )
+    repo = icechunk.Repository.open_or_create(storage)
+    session = repo.writable_session('main')
+    to_icechunk(ds, session)
+    session.commit('reproject and interp')
+
+
+def interpolate_and_reproject(climate_run_year: str):
+    climate_run_ds = load_climate_run_ds(climate_run_year)
+    rps_30 = (
+        catalog.get_dataset('USFS-wildfire-risk-communities')
+        .to_xarray()['BP']
+        .astype('float32')
+        .to_dataset()
+    )
+    # interpolate to 30m & chunk
+    interp_30 = interpolate_to_30(climate_run_ds, rps_30).chunk({'y': 6000, 'x': 4500})
+
+    # assign crs and reproject to lat/lon EPSG:4326
+    interp_30 = assign_crs(interp_30, crs='EPSG:5070')
+    climate_run_4326 = xr_reproject(interp_30, how='EPSG:4326')
+    # Write to icechunk
+    write_to_icechunk(climate_run_4326, climate_run_year)
+
+
+# WARNING: This function is using very large VM's that should not be left running!
+@coiled.function(
+    region='us-west-2',
+    n_workers=10,
+    vm_type='r7a.24xlarge',
+    scheduler_vm_types='r7a.xlarge',
+    tags={'Project': 'OCR'},
+    idle_timeout='5 minutes',
+)
+def main():
+    interpolate_and_reproject(climate_run_year='2011')
+    interpolate_and_reproject(climate_run_year='2047')
+
+
+if __name__ == '__main__':
+    main()

--- a/ocr/datasets.py
+++ b/ocr/datasets.py
@@ -451,6 +451,20 @@ datasets = [
         data_format='zarr',
     ),
     Dataset(
+        name='2011-climate-run-30m-4326',
+        description='USFS 2011 Climate Run',
+        bucket='carbonplan-ocr',
+        prefix='input/fire-risk/tensor/USFS/2011_climate_run_30m_4326_chunked_icechunk',
+        data_format='zarr',
+    ),
+    Dataset(
+        name='2047-climate-run-30m-4326',
+        description='USFS 2047 Climate Run',
+        bucket='carbonplan-ocr',
+        prefix='input/fire-risk/tensor/USFS/2047_climate_run_30m_4326_chunked_icechunk',
+        data_format='zarr',
+    ),
+    Dataset(
         name='conus-overture-addresses',
         description='CONUS Overture Addresses',
         bucket='carbonplan-ocr',


### PR DESCRIPTION
- Interpolates USFS 2011 and 2047 climate runs from 270m to 30m.
- Re-projects from `EPSG:5070` TO `EPSG:4326`
- Matches chunk sizing to match USFS community risk dataset.