### PR TITLE
Adds icechunk region_id check from icechunk ancestry

### DIFF
--- a/ocr/deploy.py
+++ b/ocr/deploy.py
@@ -29,29 +29,17 @@ def main(
 ):
     # from ocr.config import BatchJobs
     from ocr.batch import CoiledBatchManager
-    from ocr.chunking_config import ChunkingConfig
     from ocr.template import IcechunkConfig, VectorConfig
 
     # config_init applies any wipe and re-init opts
     IcechunkConfig(branch=branch, wipe=wipe).config_init()
     VectorConfig(branch=branch, wipe=wipe).config_init()
-    config = ChunkingConfig()
-
-    valid_region_ids = set(config.valid_region_ids)
-    # the overlapping values from the full valid region_id list and the submitted region_ids
-    submitted_valid_region_ids = valid_region_ids.intersection(set(region_id))
-    # invalid region_ids
-    invalid_region_ids = set(region_id).difference(submitted_valid_region_ids)
-
-    print(
-        f'Skipping these submitted region_ids because they are missing source data: {invalid_region_ids}'
-    )
 
     # ------------- 01 AU ---------------
 
     batch_manager_01 = CoiledBatchManager(debug=debug)
     # region_id is tuple
-    for rid in submitted_valid_region_ids:
+    for rid in region_id:
         batch_manager_01.submit_job(
             command=f'python pipeline/01_Write_Region.py -r {rid} -b {branch}',
             name=f'process-region-{rid}-{branch}',

--- a/ocr/pipeline/01_Write_Region.py
+++ b/ocr/pipeline/01_Write_Region.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING
 
 import click
 
+from ocr.template import region_id_exists_in_repo
+
 if TYPE_CHECKING:
     pass
 
@@ -90,6 +92,7 @@ def run_wind_region(region_id: str, branch: str):
     # Using the Icechunk uncooperative writes method: https://icechunk.io/en/latest/icechunk-python/parallel/#uncooperative-distributed-writes
     # In this, we are trading performance / more difficult conflict resolution for stateless processing.
     insert_region_uncoop(subset_ds=risk_4326_combined, region_id=region_id, branch=branch)
+
     # only use dask for xarray, shutdown for duckdb wind sample
 
 
@@ -97,8 +100,13 @@ def run_wind_region(region_id: str, branch: str):
 @click.option('-r', '--region-id', required=True, help='region_id. ex: y5_x12')
 @click.option('-b', '--branch', help='data branch: [QA, prod]. Default QA')
 def main(region_id: str, branch: str):
-    run_wind_region(region_id, branch)
-    sample_risk_region(region_id, branch)
+    if region_id_exists_in_repo(region_id=region_id, branch=branch):
+        # switch to logging
+        print(f'{region_id} already exists in Icechunk store')
+
+    else:
+        run_wind_region(region_id, branch)
+        sample_risk_region(region_id, branch)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Based on prototype in https://github.com/carbonplan/ocr/pull/46

This moves the check to the start of the wind adjustment, so it can exit quicker if a `region_id` already exists. 