### PR TITLE
revert to using apply_ufunc to compute wind direction mode along time

### DIFF
--- a/tests/risks/test_fire.py
+++ b/tests/risks/test_fire.py
@@ -94,6 +94,7 @@ class TestWindDirectionClassification:
         result = classify_wind_directions(wind_dir).values
         np.testing.assert_array_equal(result, expected)
 
+    @pytest.mark.xfail(reason='NaN handling not yet implemented')
     def test_nan_handling(self, create_test_data):
         """Test handling of NaN values."""
         angles = [0, np.nan, 90, np.nan, 180]
@@ -210,6 +211,7 @@ class TestComputeModeAlongTime:
 
         np.testing.assert_array_equal(result.values, expected)
 
+    @pytest.mark.xfail(reason='NaN handling not yet implemented')
     def test_nan_handling(self, create_test_array):
         """Test handling of NaN values."""
         # Create data with NaN values
@@ -245,9 +247,9 @@ class TestComputeModeAlongTime:
         expected = np.array(
             [
                 [NORTH, EAST],
-                [np.nan, WEST],  # Should be NaN when all values are placeholders
+                [-1, WEST],  # Should be -1 when all values are placeholders
             ],
-            dtype=np.float32,
+            dtype=np.int16,
         )
 
         np.testing.assert_array_equal(result.values, expected)
@@ -343,6 +345,7 @@ class TestComputeModeAlongTime:
         assert result.attrs['custom_attr'] == 'test_value'
         assert 'long_name' in result.attrs  # New attribute added by the function
 
+    @pytest.mark.xfail(reason='NaN handling not yet implemented')
     def test_empty_array(self, create_test_array):
         """Test with an empty array (all NaNs)."""
         data = np.full((5, 2, 2), np.nan, dtype=np.float32)


### PR DESCRIPTION
- reverts #138

i discovered that the changes i introduced in #138 ended up breaking wind direction mode calculation as seen in this workflow run: https://github.com/carbonplan/ocr/actions/runs/16953352186/job/48050500909