### PR TITLE
add ID to select statement for building pmtiles creation

### DIFF
--- a/ocr/pipeline/create_pmtiles.py
+++ b/ocr/pipeline/create_pmtiles.py
@@ -39,7 +39,6 @@ def create_pmtiles(config: OCRConfig):
         COPY (
             SELECT
                 'Feature' AS type,
-                id AS id,
                 json_object(
                     'risk_2011', risk_2011,
                     'risk_2047', risk_2047,
@@ -68,6 +67,7 @@ def create_pmtiles(config: OCRConfig):
             '-q',
             '--extend-zooms-if-still-dropping',
             '-zg',
+            '--generate-ids',
         ]
 
         _ = subprocess.run(tippecanoe_cmd, stdin=duckdb_proc.stdout, check=True)


### PR DESCRIPTION
~~Should solve #158 as long as `id` is the right attribute name (which from what I can trace should be correct).~~

using the tippecanoe --generate-ids option instead, since the geoparquet doesn't have an id column.

