### PR TITLE
Switching out equally spaced bins for custom binning

### DIFF
--- a/ocr/pipeline/fire_wind_risk_regional_aggregator.py
+++ b/ocr/pipeline/fire_wind_risk_regional_aggregator.py
@@ -73,7 +73,7 @@ def custom_histogram_query(
     then add them on to a histogram that excludes values of 0.
     """
 
-    # First temp table: zero counts by county
+    # First temp table: zero counts by county.
     zero_counts_query = f"""
     CREATE TEMP TABLE temp_zero_counts_{geo_table_name} AS
     SELECT


### PR DESCRIPTION
Switching to this schema: `0 , 0.01-5, 5.01-10, 10.01-15, 15.01-20, 20.1-25, >25`

in duckdb left open syntax: `[5, 10, 15, 20, 25, 100]`

