### PR TITLE
Add `pretty_paths()` method to configuration classes

### DIFF
--- a/ocr-coiled-s3-production.env
+++ b/ocr-coiled-s3-production.env
@@ -1,3 +1,4 @@
 OCR_ENVIRONMENT = 'production'
 OCR_STORAGE_ROOT = 's3://carbonplan-ocr'
 OCR_DEBUG = '1'
+OCR_VERSION = '0.1.0'

--- a/ocr/deploy/cli.py
+++ b/ocr/deploy/cli.py
@@ -7,6 +7,7 @@ import dotenv
 import typer
 
 from ocr.config import OCRConfig, load_config
+from ocr.console import console
 from ocr.deploy.managers import _get_manager
 from ocr.types import Platform, RiskType
 
@@ -302,6 +303,11 @@ def run(
             },
         )
         manager.wait_for_completion(exit_on_failure=True)
+
+    if config.debug:
+        # Print out the pretty paths
+        console.log('Run complete. Current configuration paths:')
+        config.pretty_paths()
 
 
 @app.command()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -502,6 +502,29 @@ class TestVectorConfig:
         # which still contains 'geoparquet-regions', so the check passes
         config.delete_region_gpqs()  # Should not raise
 
+    def test_pretty_paths_output_and_side_effects(self, temp_dir, capsys):
+        """pretty_paths should print a readable table and create expected dirs."""
+        config = VectorConfig(storage_root=temp_dir)
+
+        # call pretty printer (touches cached properties that mkdir)
+        config.pretty_paths()
+
+        out = capsys.readouterr().out
+        # Check some key rows appear in output
+        assert 'Vector setting' in out
+        assert 'Geoparquet prefix' in out
+        assert 'Region Geoparquet URI' in out
+        assert 'PMTiles prefix' in out
+
+        # Verify directories were created as a side-effect
+        assert config.region_geoparquet_uri.exists()
+        assert config.region_geoparquet_uri.is_dir()
+        assert config.region_summary_stats_prefix.exists()
+        assert config.region_summary_stats_prefix.is_dir()
+        # pmtiles and geoparquet parents should exist
+        assert config.building_geoparquet_uri.parent.exists()
+        assert config.buildings_pmtiles_uri.parent.exists()
+
 
 # ============= IcechunkConfig Tests =============
 
@@ -678,6 +701,16 @@ class TestIcechunkConfig:
         exists = config.region_id_exists('Repository initialized')
         assert exists
 
+    def test_pretty_paths_output(self, temp_dir, capsys):
+        """pretty_paths should print repo URI and protocol."""
+        cfg = IcechunkConfig(storage_root=temp_dir, prefix='test-icechunk')
+
+        cfg.pretty_paths()
+        out = capsys.readouterr().out
+        assert 'Icechunk setting' in out
+        assert 'Repository URI' in out
+        assert 'Protocol' in out
+
 
 # ============= OCRConfig Tests =============
 
@@ -727,6 +760,21 @@ class TestOCRConfig:
 
                 assert config.environment == Environment.PRODUCTION
                 assert config.storage_root == temp_dir
+
+    def test_pretty_paths_combined_output_and_side_effects(self, temp_dir, capsys):
+        """OCRConfig.pretty_paths should include sub-config pretty outputs and create dirs."""
+        cfg = OCRConfig(storage_root=temp_dir)
+
+        cfg.pretty_paths()
+        out = capsys.readouterr().out
+        # Expect the three sections
+        assert 'OCR setting' in out
+        assert 'Vector setting' in out
+        assert 'Icechunk setting' in out
+
+        # Vector pretty_paths should have created expected directories
+        assert cfg.vector.region_geoparquet_uri.exists()
+        assert cfg.vector.region_summary_stats_prefix.exists()
 
 
 # ============= Integration Tests =============


### PR DESCRIPTION
adds a convenience method for printing the configuration values

```python
In [1]: from ocr.config import load_config, OCRConfig

In [2]: config = OCRConfig(storage_root="/tmp/test", debug=True)

In [3]: config.pretty_paths()
╭─ OCRConfig paths ──────────────────────────────────────────────────────────────────────────────╮
│ ┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┓                                                                   │
│ ┃ OCR setting  ┃ Value     ┃                                                                   │
│ ┡━━━━━━━━━━━━━━╇━━━━━━━━━━━┩                                                                   │
│ │ Environment  │ qa        │                                                                   │
│ │ Version      │ —         │                                                                   │
│ │ Storage root │ /tmp/test │                                                                   │
│ └──────────────┴───────────┘                                                                   │
╰────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ VectorConfig paths ───────────────────────────────────────────────────────────────────────────╮
│ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓ │
│ ┃ Vector setting           ┃ Value                                                           ┃ │
│ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩ │
│ │ Environment              │ qa                                                              │ │
│ │ Version                  │ —                                                               │ │
│ │ Storage root             │ /tmp/test                                                       │ │
│ │ Intermediate prefix      │ intermediate/fire-risk/vector/qa                                │ │
│ │ Output prefix            │ output/fire-risk/vector/qa                                      │ │
│ │ Geoparquet prefix        │ output/fire-risk/vector/qa/geoparquet                           │ │
│ │ Region Geoparquet prefix │ intermediate/fire-risk/vector/qa/geoparquet-regions             │ │
│ │ PMTiles prefix           │ output/fire-risk/vector/qa/pmtiles                              │ │
│ │ Region Geoparquet URI    │ /tmp/test/intermediate/fire-risk/vector/qa/geoparquet-regions   │ │
│ │ Buildings Geoparquet URI │ /tmp/test/output/fire-risk/vector/qa/geoparquet/buildings.parq… │ │
│ │ Region summary stats dir │ /tmp/test/output/fire-risk/vector/qa/region-summary-stats       │ │
│ │ Tracts summary stats     │ /tmp/test/output/fire-risk/vector/qa/region-summary-stats/trac… │ │
│ │ Counties summary stats   │ /tmp/test/output/fire-risk/vector/qa/region-summary-stats/coun… │ │
│ │ Buildings PMTiles        │ /tmp/test/output/fire-risk/vector/qa/pmtiles/buildings.pmtiles  │ │
│ │ Tracts PMTiles           │ /tmp/test/output/fire-risk/vector/qa/pmtiles/tracts.pmtiles     │ │
│ │ Counties PMTiles         │ /tmp/test/output/fire-risk/vector/qa/pmtiles/counties.pmtiles   │ │
│ └──────────────────────────┴─────────────────────────────────────────────────────────────────┘ │
╰────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ IcechunkConfig paths ─────────────────────────────────────────────────────────────────────────╮
│ ┏━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓                       │
│ ┃ Icechunk setting ┃ Value                                             ┃                       │
│ ┡━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩                       │
│ │ Environment      │ qa                                                │                       │
│ │ Version          │ —                                                 │                       │
│ │ Storage root     │ /tmp/test                                         │                       │
│ │ Prefix           │ output/fire-risk/tensor/qa/ocr.icechunk           │                       │
│ │ Repository URI   │ /tmp/test/output/fire-risk/tensor/qa/ocr.icechunk │                       │
│ │ Protocol         │ file                                              │                       │
│ └──────────────────┴───────────────────────────────────────────────────┘                       │
╰────────────────────────────────────────────────────────────────────────────────────────────────╯
```