### PR TITLE
Add QA deployment job for pull requests in GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -56,7 +56,16 @@ env:
 jobs:
   qa-pr:
     # Automatic non-production deploy on PR to main (qa env, limited regions, wipe each time)
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' &&  (
+      (
+      contains(github.event.pull_request.labels.*.name, 'e2e') ||
+      contains(github.event.pull_request.labels.*.name, 'QA/QC')
+      ) ||
+      (
+      contains(github.event.pull_request.title, '[e2e]') ||
+      contains(github.event.pull_request.body, '[e2e]')
+      )
+      )
     environment:
       name: qa
       url: ${{ env.QA_URL }}


### PR DESCRIPTION
This pull request adds a `pull_request` trigger for the deployment workflow, so that the workflow runs automatically for PRs (labeled with `QA/QC` or `e2e`)  targeting the `main` branch.  this deploys only to limited regions (`y2_x3`, `y2_x4`, `y2_x5`) and wipes the environment each time

Cc @katamartin / @norlandrhagen / @orianac / @Shane98c for visibility 