### PR TITLE
standardize Coiled configuration and enable production reruns for vector regeneration

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -414,6 +414,7 @@ jobs:
               env:
                   DASK_COILED__TOKEN: ${{ secrets.DASK_COILED__TOKEN }}
                   OCR_ENVIRONMENT: ${{ env.OCR_ENVIRONMENT }}
+                  OCR_ALLOW_ALL_PROCESSED: "true"
               run: |
                   cat ocr-coiled-s3-production.env
                   echo "Running production deployment for tag: $OCR_VERSION (environment=$OCR_ENVIRONMENT)"
@@ -517,6 +518,7 @@ jobs:
               env:
                   DASK_COILED__TOKEN: ${{ secrets.DASK_COILED__TOKEN }}
                   OCR_ENVIRONMENT: ${{ env.OCR_ENVIRONMENT }}
+                  OCR_ALLOW_ALL_PROCESSED: "true"
               run: |
                   cat ocr-coiled-s3-production.env
                   REGION_ARGS="--all-region-ids"


### PR DESCRIPTION
added `OCR_ALLOW_ALL_PROCESSED` environment variable to allow production reruns:
- When set to `"true"`, the pipeline can proceed with vector processing even if all icechunk regions are already processed
- modified `OCRConfig.resolve_region_ids()` and `select_region_ids()` to accept `allow_all_processed` parameter

