### PR TITLE
add note about buildings being assigned to multiple regions if exactly on border

### DIFF
--- a/docs/access-data.md
+++ b/docs/access-data.md
@@ -38,10 +38,10 @@ The schemas for each of the full datasets are described on the [data schema](./r
 
 ## Regional statistics downloads
 
-:::{note}  
- In rare cases, buildings with centroids situated exactly on regional boundaries may be counted in both
-region's statistics.  
- :::
+:::{note}
+In rare cases, buildings with centroids situated exactly on regional boundaries may be counted in both
+region's statistics.
+:::
 
 ### Links
 


### PR DESCRIPTION
Adding a note in the `Regional statistics downloads` docs about the issue of buildings being counted twice if they're right on a boundary line. 

other potential spot @katamartin flagged was https://open-climate-risk.readthedocs.io/en/latest/how-to/data-pipeline.html#ocr-partition-buildings-data-consolidation but not 100% sure the issue applies there too or if that's deduplicated somehow. @norlandrhagen wdyt?